### PR TITLE
Add ++cat alias to ++randomcat command

### DIFF
--- a/runtime/commands/fun.js
+++ b/runtime/commands/fun.js
@@ -75,9 +75,10 @@ Commands.fortunecow = {
   }
 }
 
-Commands.cat = {
-  name: 'cat',
+Commands.randomcat = {
+  name: 'randomcat',
   help: "I'll get a random cat image for you!",
+  aliases: ['cat'],
   module: 'fun',
   timeout: 10,
   level: 0,

--- a/runtime/commands/fun.js
+++ b/runtime/commands/fun.js
@@ -75,8 +75,8 @@ Commands.fortunecow = {
   }
 }
 
-Commands.randomcat = {
-  name: 'randomcat',
+Commands.cat = {
+  name: 'cat',
   help: "I'll get a random cat image for you!",
   module: 'fun',
   timeout: 10,


### PR DESCRIPTION
Nyaamaste!

Time to simplify the name of ``++randomcat`` to ``++cat``. This is both
easier to type, and there's the added benefit of using the same naming
convention as the other bots on the market (which are quite frankly not
as good as WildBeast).